### PR TITLE
Add CLI script for parsing PGNs to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ A code example to read a complete game then looks like:
       ]
     }
 
+## How to use it as an CLI?
+
+You can use `pgn-parser` as a command line tool for parsing PGN files to JSON
+
+``` bash
+npm install --global pgn-parser
+pgn-parser file.pgn
+
+# Or
+
+npx pgn-parser file.pgn
+```
+
 ## How to use it in the browser?
 
 If you want to use the library in the browser, the above method will not work. In the [ticket 22](https://github.com/mliebelt/pgn-parser/issues/22), Bebul explained how to do it. Here is the complete recipe:

--- a/bin/pgn-to-json.js
+++ b/bin/pgn-to-json.js
@@ -1,0 +1,110 @@
+#! /usr/bin/env node
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { parser } = require("..");
+
+const STDIN_FILE_NO = 0;
+
+const usage = () => `\
+Parse PGN files to JSON.
+
+USAGE:
+  pgn-to-json [options] [FILE]...
+
+OPTIONS:
+  -h, --help       Show help
+  -p, --pretty     Output formatted json
+
+ARGS:
+  <FILE>...     PGN file(s) to parse as JSON. Use '-' for stdin.
+                If no FILE is provided it reads from stdin`;
+
+const processArguments = (process) => {
+  const args = process.argv.slice(2);
+  const files = [];
+  const options = {};
+
+  for (const arg of args) {
+    if (arg.startsWith('-')) {
+      switch (arg) {
+        case '-h':
+        case '--help':
+          options.help = true;
+          break;
+
+        case '-p':
+        case '--pretty':
+          options.pretty = true;
+          break;
+
+        case '-':
+          files.push(0);
+          break;
+
+        default:
+          throw Error(`Unknown option ${arg}`);
+      }
+    } else {
+      files.push(arg)
+    }
+  }
+
+  if (files.length === 0) {
+    files.push(0);
+  }
+
+  return { files, options }
+};
+
+const filesToJson = (files) => {
+  const games = [];
+
+  for (const file of files) {
+    const fileContent = fs
+      .readFileSync(file === 0 ? file : path.resolve(file))
+      .toString()
+      .trim();
+
+    if (fileContent) {
+      const gamesOnFile = parser.parse(fileContent, { startRule: "games" });
+
+      games.push(...gamesOnFile);
+    }
+  }
+
+  return games;
+};
+
+const main = (process) => {
+  let arguments
+  try {
+    arguments = processArguments(process);
+  } catch(e) {
+    console.error(e.message)
+    console.log(usage())
+    process.exit(1)
+    return
+  }
+
+  const { files, options } = arguments
+
+  if (options.help) {
+    console.log(usage())
+    process.exit(0)
+    return
+  }
+
+  const gamesParsed = filesToJson(files);
+
+  const gamesJson = (
+    options.pretty
+      ? JSON.stringify(gamesParsed, null, 2)
+      : JSON.stringify(gamesParsed)
+  )
+
+  console.log(gamesJson)
+};
+
+main(process);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "sampleGame.pgn",
     "README.md"
   ],
+  "bin": "./bin/pgn-to-json.js",
   "author": "mliebelt",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR adds a script for parsing PGNs into JSON from the command line.

You can call the package directly from `npx`:
``` bash
npx pgn-parser <files>...
```

Or install it globally and call the command after:
``` bash
npm install -g pgn-parser
cat game.pgn | pgn-parser
```

There's an option for displaying formatted output or simple JSON, `-p` or `--pretty`. You can also pipe the file from stdin