### PR TITLE
Fix docs for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pgn-parser file.pgn
 
 # Or
 
-npx pgn-parser file.pgn
+npx @mliebelt/pgn-parser file.pgn
 ```
 
 The optional parameter `-p` emits the result pretty-printed.


### PR DESCRIPTION
The docs on README were pointing to the wrong npm package. I also took the opportunity to make some small enhancements to it. Adding a new option `--` for parsing everything after it as a file name, and some small code changes