### PR TITLE
Add chessbase colors to pgn-rules

### DIFF
--- a/src/pgn-rules.pegjs
+++ b/src/pgn-rules.pegjs
@@ -340,6 +340,8 @@ color
   / "G" { return "G"; } // green
   / "R" { return "R"; } // red
   / "B" { return "B"; } // blue
+  / "O" { return "O"; } // orange
+  / "C" { return "C"; } // magenta
 
 field
   = col:column row:row { return col + row; }


### PR DESCRIPTION
Chessbase has additional colors O (orange) and C (magenta) that are not being recognized by colorArrows and colorFields. This commit adds them to the color rule.